### PR TITLE
Moving newline to end of line rather than beginning of line

### DIFF
--- a/tasks/svn_fetch.js
+++ b/tasks/svn_fetch.js
@@ -51,7 +51,7 @@ module.exports = function (grunt) {
 				} else {
 					command = [ command, 'checkout', options.repository + map[path], fullPath ].join(' ');
 				}
-				grunt.log.write('\nProcessing ' + fullPath);
+				grunt.log.write('Processing ' + fullPath + '\n');
 				exec(command, options.execOptions, function (error, stdout) {
 					grunt.log.write(stdout);
 					if (error !== null) {


### PR DESCRIPTION
This little pull request fixes a problem I've seen running grunt-svn-fetch on OS/X, where the `svn` output is concatenated with log lines in the output, like this:

```
% grunt svn
Running "svn_fetch:svn" (svn_fetch) task

Processing puppet/svn/apacheUpdating 'puppet/svn/apache':
At revision 31073.

Processing puppet/svn/limitsUpdating 'puppet/svn/limits':
At revision 31073.
```

Possibly other svn clients output their newlines in a different format. This fix works for me, though.
