### PR TITLE
Add svn options control

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,12 @@ Specifies the location of the SVN binary.
 #### options.execOptions
 Type: 'Object'
 
+#### options.execOptions
+Type: 'Object'
+
 Default value: `{}`
 
-#### options.svnOptions
-Type: 'Object'
+Specifies any options to pass to the `exec` command when executing the svn cli statements. For example, it may be necessary to increase the default `maxBuffer` for larger repositories.
 
 Default value: `{}`
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ Specifies the location of the SVN binary.
 #### options.execOptions
 Type: 'Object'
 
-#### options.execOptions
-Type: 'Object'
-
 Default value: `{}`
 
 Specifies any options to pass to the `exec` command when executing the svn cli statements. For example, it may be necessary to increase the default `maxBuffer` for larger repositories.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,115 @@ Specifies any options to pass to the `exec` command when executing the svn cli s
 #### options.repository
 Type: `String`
 
+Default value: `''`# grunt-svn-fetch
+
+> Ensures specified files are checked out or updated from SVN repository.
+
+## Getting Started
+This plugin requires Grunt `~0.4.0`
+
+If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
+
+	npm install grunt-svn-fetch --save-dev
+
+One the plugin has been installed, it may be enabled inside your Gruntfile with this line of JavaScript:
+
+	grunt.loadNpmTasks('grunt-svn-fetch');
+
+## The "svn_fetch" task
+
+### Overview
+In your project's Gruntfile, add a section named `svn_fetch` to the data object passed into `grunt.initConfig()`.
+
+	grunt.initConfig({
+		svn_fetch: {
+			options: {
+				// Task-specific options go here.
+			},
+			your_target: {
+				options: {
+					// Target-specific settings and/or options go here.
+				}
+			},
+		},
+	})
+
+The task works by checking for the presence of the ```.svn``` folder under each of the target folders. If present, an update is performed, otherwise a checkout is done.
+
+### Options
+
+#### options.bin
+Type: `String`
+
+Default value: `'svn'`
+
+Specifies the location of the SVN binary.
+
+#### options.execOptions
+Type: 'Object'
+
+Default value: `{}`
+
+#### options.svnOptions
+Type: 'Object'
+
+Default value: `{}`
+
+Specifies any options to pass to the `svn` command. For example you can specify your credentials as follows:
+
+```js
+svnOptions: {
+	username: 'paul',
+	password: 'paulpasswd'
+}
+```
+
+#### options.repository
+Type: `String`
+
 Default value: `''`
+
+The URL of the SVN repository.
+
+#### options.path
+Type: `String`
+
+Default value: `''`
+
+The base element of the path to where checked out or updated files are placed.
+
+### Usage Examples
+
+	grunt.initConfig({
+		svn_fetch: {
+			options: {
+				'repository':	'https://my_repos.com/projectX/trunk/',
+				'path': 		'/svn/projectX/src/'
+			},
+			projectX: {
+	    		map: {
+			    	'folderX': 'SVNFolderX',
+					'folderY': 'SVNFolderY'
+				}
+			}
+	    },
+	});
+
+Each entry in ```map``` utilises the ```path``` and ```respository``` options to determine the full path and URL of the items being considered. So, in this case, the first entry would resolve to:
+
+	/svn/projectX/src/folderX
+
+and
+
+	https://my_repos.com/projectX/trunk/SVNFolderX
+
+Note the inclusion of slashes on the option entries. The plugin makes no effort to ensure slashes are correct.
+
+## Release History
+* 2013-03-13 0.1.0 Initial release
+* 2013-03-13 0.1.2 Issue #1 fixed
+* 2013-12-11 0.1.3 Issue #2 fixed
+
 
 The URL of the SVN repository.
 

--- a/README.md
+++ b/README.md
@@ -47,60 +47,6 @@ Type: 'Object'
 
 Default value: `{}`
 
-Specifies any options to pass to the `exec` command when executing the svn cli statements. For example, it may be necessary to increase the default `maxBuffer` for larger repositories.
-
-#### options.repository
-Type: `String`
-
-Default value: `''`# grunt-svn-fetch
-
-> Ensures specified files are checked out or updated from SVN repository.
-
-## Getting Started
-This plugin requires Grunt `~0.4.0`
-
-If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
-
-	npm install grunt-svn-fetch --save-dev
-
-One the plugin has been installed, it may be enabled inside your Gruntfile with this line of JavaScript:
-
-	grunt.loadNpmTasks('grunt-svn-fetch');
-
-## The "svn_fetch" task
-
-### Overview
-In your project's Gruntfile, add a section named `svn_fetch` to the data object passed into `grunt.initConfig()`.
-
-	grunt.initConfig({
-		svn_fetch: {
-			options: {
-				// Task-specific options go here.
-			},
-			your_target: {
-				options: {
-					// Target-specific settings and/or options go here.
-				}
-			},
-		},
-	})
-
-The task works by checking for the presence of the ```.svn``` folder under each of the target folders. If present, an update is performed, otherwise a checkout is done.
-
-### Options
-
-#### options.bin
-Type: `String`
-
-Default value: `'svn'`
-
-Specifies the location of the SVN binary.
-
-#### options.execOptions
-Type: 'Object'
-
-Default value: `{}`
-
 #### options.svnOptions
 Type: 'Object'
 
@@ -119,48 +65,6 @@ svnOptions: {
 Type: `String`
 
 Default value: `''`
-
-The URL of the SVN repository.
-
-#### options.path
-Type: `String`
-
-Default value: `''`
-
-The base element of the path to where checked out or updated files are placed.
-
-### Usage Examples
-
-	grunt.initConfig({
-		svn_fetch: {
-			options: {
-				'repository':	'https://my_repos.com/projectX/trunk/',
-				'path': 		'/svn/projectX/src/'
-			},
-			projectX: {
-	    		map: {
-			    	'folderX': 'SVNFolderX',
-					'folderY': 'SVNFolderY'
-				}
-			}
-	    },
-	});
-
-Each entry in ```map``` utilises the ```path``` and ```respository``` options to determine the full path and URL of the items being considered. So, in this case, the first entry would resolve to:
-
-	/svn/projectX/src/folderX
-
-and
-
-	https://my_repos.com/projectX/trunk/SVNFolderX
-
-Note the inclusion of slashes on the option entries. The plugin makes no effort to ensure slashes are correct.
-
-## Release History
-* 2013-03-13 0.1.0 Initial release
-* 2013-03-13 0.1.2 Issue #1 fixed
-* 2013-12-11 0.1.3 Issue #2 fixed
-
 
 The URL of the SVN repository.
 

--- a/tasks/svn_fetch.js
+++ b/tasks/svn_fetch.js
@@ -19,7 +19,8 @@ module.exports = function (grunt) {
 			bin:         'svn',
 			repository:  '',
 			path:        '',
-			execOptions: {}
+			execOptions: {},
+			svnOptions: {}
 		});
 		var done = this.async();
 		var map = this.data.map;
@@ -50,6 +51,9 @@ module.exports = function (grunt) {
 					command = [ command, 'update', fullPath ].join(' ');
 				} else {
 					command = [ command, 'checkout', options.repository + map[path], fullPath ].join(' ');
+				}
+				for (var key in options.svnOptions) {
+					command += ' --' + key + "='" + options.svnOptions[key] +"'"
 				}
 				grunt.log.write('Processing ' + fullPath + '\n');
 				exec(command, options.execOptions, function (error, stdout) {


### PR DESCRIPTION
This Grunt plugin is a great use, but I when you need to specify svn options (like credentials), you can't use it. I added a simple svnOptions options object that adds them to the executed command.